### PR TITLE
nuevo evento filtra guard ocupado y shift asignado

### DIFF
--- a/back/api/services/events.js
+++ b/back/api/services/events.js
@@ -12,8 +12,34 @@ const moment = require("moment");
 class EventsService {
   // CREATE EVENT
   static async createEvent(body) {
-    console.log(body);
+    const { shiftId, branchId, date, guardId } = body;
+
     try {
+      //check if dont exist other event with same shift
+      const evento = await Event.findOne({
+        where: { date, shiftId, branchId },
+      });
+      if (evento) {
+        return {
+          error: true,
+          data: {
+            status: 409,
+            message: `Ya hay un guardia asignado para ese turno`,
+          },
+        };
+      }
+      //check if the guard are not busy on this date
+      const guardiaOcupado = await Event.findOne({ where: { date, guardId } });
+      if (guardiaOcupado) {
+        return {
+          error: true,
+          data: {
+            status: 409,
+            message: `El guardia con id:${guardId} ya tiene asignado un evento el día ${date}`,
+          },
+        };
+      }
+
       const response = await Event.create(body);
       return { error: false, data: response };
     } catch (error) {

--- a/back/api/services/guards.js
+++ b/back/api/services/guards.js
@@ -72,6 +72,7 @@ class GuardsService {
           exclude: ["password", "salt", "createdAt", "updatedAt"],
         },
       });
+
       // filtramos guardias que se encuentran como máxim a 50km de la sucursal
       const response = guards.filter(
         (guard) =>


### PR DESCRIPTION
Agregué al services de nuevo evento, que no pueda agregar un evento si el guardia ya tiene un turno asignado ese día y tampoco si ya hay alguien asignado ese día en ese mismo turno (o sea solo un guardia por turno por sucursal)